### PR TITLE
Fix bundling where window is undefined

### DIFF
--- a/lib/CSSLoaderDOM.js
+++ b/lib/CSSLoaderDOM.js
@@ -2,12 +2,12 @@
 import debounce from 'debounce';
 import { CSSModuleLoaderProcess } from './CSSModuleLoaderProcess';
 
-const USE_STYLE_TAGS = !window.Blob || !window.URL || !URL.createObjectURL || navigator.userAgent.match(/phantomjs/i)
+const USE_STYLE_TAGS = typeof window === 'undefined' || !window.Blob || !window.URL || !URL.createObjectURL || navigator.userAgent.match(/phantomjs/i)
 
 export class CSSLoaderDOM extends CSSModuleLoaderProcess {
   constructor (plugins) {
     super(plugins);
-	
+
     this._jspmCssModulesContainer = document.createElement('jspm-css-modules');
     this._debouncedSortingAndInject = debounce(this._sortAndInjectInDom, 500).bind(this);
 
@@ -16,7 +16,7 @@ export class CSSLoaderDOM extends CSSModuleLoaderProcess {
 
   fetch (load, systemFetch) {
     let styleSheet;
-	
+
     return super.fetch(load, systemFetch)
       .then((_styleSheet) => styleSheet = _styleSheet)
       .then(this._storeInBlobs)


### PR DESCRIPTION
This was previously coverd by the _BUILD_MODE.js_ file but it has been
removed in 306e222c98f14707ab96be88909bbe1f75b5b67
