### PR TITLE
Add an option to produce a separate CSS file

### DIFF
--- a/lib/CSSLoaderBuilded.js
+++ b/lib/CSSLoaderBuilded.js
@@ -3,12 +3,27 @@ import { CSSModuleLoaderProcess } from './CSSModuleLoaderProcess';
 const CSS_INJECT_FUNCTION = "(function(c){if (typeof document == 'undefined') return; var d=document,a='appendChild',i='styleSheet',s=d.createElement('style');s.type='text/css';d.getElementsByTagName('head')[0][a](s);s[i]?s[i].cssText=c:s[a](d.createTextNode(c));})";
 const EMPTY_SYSTEM_REGISTER = (system, name) => `${system}.register('${name}', [], function() { return { setters: [], execute: function() {}}});`;
 
+var that;
+
+function escape(source) {
+  return source
+    .replace(/(["\\])/g, '\\$1')
+    .replace(/[\f]/g, "\\f")
+    .replace(/[\b]/g, "\\b")
+    .replace(/[\n]/g, "\\n")
+    .replace(/[\t]/g, "\\t")
+    .replace(/[\r]/g, "\\r")
+    .replace(/[\']/g, "\\'")
+    .replace(/[\u2028]/g, "\\u2028")
+    .replace(/[\u2029]/g, "\\u2029");
+}
+
 export class CSSLoaderBuilded extends CSSModuleLoaderProcess {
   constructor (plugins) {
     super(plugins);
 
-    // enforce this on exported functions
-    this.bundle = this.bundle.bind(this);
+    // keep a reference to the class instance
+    that = this;
   }
 
   fetch (load, systemFetch) {
@@ -17,29 +32,56 @@ export class CSSLoaderBuilded extends CSSModuleLoaderProcess {
       .then((styleSheet) => styleSheet.exportedTokens);
   }
 
-  bundle (loads, compileOpts) {
-    const fileDefinitions = loads
-      .map((load) => EMPTY_SYSTEM_REGISTER(compileOpts.systemGlobal || 'System', load.name))
-      .join('\n');
-	  
-	// Fake file definitions and inject all the css
-    return `${fileDefinitions}${CSS_INJECT_FUNCTION}('${this._getAllSources()}');`;
+  bundle (loads, compileOpts, outputOpts) {
+    var loader = this;
+    if (loader.buildCSS === false)
+      return '';
+
+    return loader['import']('cssnano').then(function(cssnano) {
+      var rootURL = loader.rootURL;
+      var outFile = loader.separateCSS ? outputOpts.outFile.replace(/\.js$/, '.css') : rootURL;
+
+      return cssnano.process(that._getAllSources(), {safe: true}).then(function (result) {
+        var cssOutput = result.css;
+
+        const fileDefinitions = loads
+          .map((load) => EMPTY_SYSTEM_REGISTER(compileOpts.systemGlobal || 'System', load.name))
+          .join('\n');
+
+        // write a separate CSS file if necessary
+        if (loader.separateCSS) {
+          // it's bad to do this in general, as code is now heavily environment specific
+          var fs = System._nodeRequire('fs');
+          if (outputOpts.sourceMaps) {
+            fs.writeFileSync(outFile + '.map', result.map);
+            cssOutput += '/*# sourceMappingURL=' + outFile.split(/[\\/]/).pop() + '.map*/'
+          }
+
+          fs.writeFileSync(outFile, cssOutput);
+
+          return fileDefinitions;
+        }
+
+        // Fake file definitions and inject all the css
+        return `
+        // Fake file definitions
+        ${fileDefinitions}
+        // Inject all the css
+        ${CSS_INJECT_FUNCTION}
+        ('${escape(cssOutput)}');`
+      });
+    }, function(err) {
+      if (err.toString().indexOf('ENOENT') != -1)
+        throw new Error('Install cssnano via `jspm install npm:cssnano --dev` for CSS build support. Set System.buildCSS = false to skip CSS builds.');
+      throw err
+    });
   }
 
   _getAllSources () {
     const sortedDependencies = this._getSortedStylesDependencies();
-	
+
     return sortedDependencies
       .map((depName) => this._styleMeta.get(depName).injectableSource)
-      .join('\n')
-	  // TODO: What is being sanitized here?
-      .replace(/(['\\])/g, '\\$1')
-      .replace(/[\f]/g, '\\f')
-      .replace(/[\b]/g, '\\b')
-      .replace(/[\n]/g, '\\n')
-      .replace(/[\t]/g, '\\t')
-      .replace(/[\r]/g, '\\r')
-      .replace(/[\u2028]/g, '\\u2028')
-      .replace(/[\u2029]/g, '\\u2029');
+      .join('\n');
   }
 };


### PR DESCRIPTION
Using cssnano instead of clean-css as discussed here[1]

Note that there as some dowside with cssnano:
1. cssnano depends on svgo which uses dynamic requires[2] which is not
supported by jspm[3]
2. cssnano is slower than clean-css due to it's modularity[4]
3. cssnano does not seem to support input source maps, as done in clean-css[5]

1/ We can work around this problem by using the meta property in jspm to
list all the dependencies (this must be done in ALL projects, which is kind
of cumbersome).

``` js
  meta: {
    "npm:svgo@0.6.1/lib/svgo/config": {
      "deps": [
        "../../plugins/removeDoctype",
        "../../plugins/removeXMLProcInst",
        "../../plugins/removeComments",
        "../../plugins/removeMetadata",
        "../../plugins/removeEditorsNSData",
        "../../plugins/cleanupAttrs",
        "../../plugins/minifyStyles",
        "../../plugins/convertStyleToAttrs",
        "../../plugins/cleanupIDs",
        "../../plugins/removeRasterImages",
        "../../plugins/removeUselessDefs",
        "../../plugins/cleanupNumericValues",
        "../../plugins/cleanupListOfValues",
        "../../plugins/convertColors",
        "../../plugins/removeUnknownsAndDefaults",
        "../../plugins/removeNonInheritableGroupAttrs",
        "../../plugins/removeUselessStrokeAndFill",
        "../../plugins/removeViewBox",
        "../../plugins/cleanupEnableBackground",
        "../../plugins/removeHiddenElems",
        "../../plugins/removeEmptyText",
        "../../plugins/convertShapeToPath",
        "../../plugins/moveElemsAttrsToGroup",
        "../../plugins/moveGroupAttrsToElems",
        "../../plugins/collapseGroups",
        "../../plugins/convertPathData",
        "../../plugins/convertTransform",
        "../../plugins/removeEmptyAttrs",
        "../../plugins/removeEmptyContainers",
        "../../plugins/mergePaths",
        "../../plugins/removeUnusedNS",
        "../../plugins/transformsWithOnePath",
        "../../plugins/sortAttrs",
        "../../plugins/removeTitle",
        "../../plugins/removeDesc",
        "../../plugins/removeDimensions",
        "../../plugins/removeAttrs",
        "../../plugins/addClassesToSVGElement",
        "../../plugins/removeStyleElement"
      ]
    }
  },
```

2/ I haven't benchmarked the bundle, so I cannot say if it is true or not.

3/ Input source maps are especially useful when writing CSS Modules with
Sass/Less

[1] https://github.com/geelen/jspm-loader-css/pull/49
[2] https://github.com/svg/svgo/blob/master/lib/svgo/config.js#L99
[3] https://github.com/jspm/registry/issues/221
[4] https://github.com/ben-eb/cssnano/issues/7
[5] https://github.com/jakubpawlowicz/clean-css/tree/3.4#how-to-generate-source-maps
