### PR TITLE
Support hot reloading

### DIFF
--- a/src/browserLoader.js
+++ b/src/browserLoader.js
@@ -55,6 +55,14 @@ export default class BrowserLoader extends AbstractLoader {
   }
 
   _appendLink(styleSheet, resolve, reject) {
+
+    const existing = document.getElementById(styleSheet.name); 
+    if (existing) {
+      existing.href = styleSheet.blobUrl;
+      resolve(styleSheet);
+      return;
+    }
+
     const link = document.createElement('link');
     link.id = styleSheet.name;
     link.rel = 'stylesheet';


### PR DESCRIPTION
This will allow `link` elements that already exist when `_appendLink` is called to have their `href` attribute changed rather than another `link` element added.
