### PR TITLE
Fixing javascript error where module.exports was invalid.

### DIFF
--- a/src/abstractLoader.js
+++ b/src/abstractLoader.js
@@ -38,7 +38,7 @@ export default class CSSModuleLoaderProcess {
             module.exports = proxy;
         `;
         } else {
-          exportedTokens = `module.exports = ${exportTokensString};`;
+          exportedTokens = `module.exports = JSON.parse('${exportTokensString}');`;
         }
 
         return {


### PR DESCRIPTION
This fixes the bug described below. I'm not sure if this will break the thing that @Mosho1 was trying to fix since I don't know how to replicate what he was seeing. But I don't see any reason why we would want `module.exports` to equal a stringified object instead of a real object.

```
err  MultipleErrors: Error compiling cjs module "src/source-forms/inputs/inputs.style.css!github:MeoMix/jspm-loader-css@master/index.js" at src/source-forms/inputs/inputs.style.css
  src/source-forms/inputs/inputs.style.css:1:19: Invalid unicode escape sequence in identifier
src/source-forms/inputs/inputs.style.css:1:19: Character code '0' is not a valid identifier start char
src/source-forms/inputs/inputs.style.css:1:20: Unterminated String Literal
src/source-forms/inputs/inputs.style.css:1:19: Unexpected token error
src/source-forms/inputs/inputs.style.css:1:20: Semi-colon expected
```

I added a logging statement at https://github.com/MeoMix/jspm-loader-css/blob/master/src/abstractLoader.js#L43 and exportedTokens is invalid javascript:

```
module.exports = {\"mainContent\":\"_src_engagements_engagements_menu_style__mainContent\"};
module.exports = {\"blockName\":\"_src_source_forms_blocks_block_styles__blockName\",\"block\":\"_src_source_forms_blocks_block_styles__block\",\"loaderWrapper\":\"_src_source_forms_blocks_block_styles__loaderWrapper\",\"loader\":\"_src_source_forms_blocks_block_styles__loader\"};
module.exports = {\"formSwitch\":\"_src_source_forms_form_view_switch_style__formSwitch\",\"formSwitchImage\":\"_src_source_forms_form_view_switch_style__formSwitchImage\",\"formSwitchSpan\":\"_src_source_forms_form_view_switch_style__formSwitchSpan\"};
module.exports = {\"sectionHeader\":\"_src_source_forms_sections_section_style__sectionHeader\",\"sectionHeaderSkirt\":\"_src_source_forms_sections_section_style__sectionHeaderSkirt\",\"root\":\"_src_source_forms_sections_section_style__root\",\"sectionFooter\":\"_src_source_forms_sections_section_style__sectionFooter\",\"footerButton\":\"_src_source_forms_sections_section_style__footerButton\"};
module.exports = {\"rootEl\":\"_src_tax_forms_tax_form_preview_style__rootEl\",\"image\":\"_src_tax_forms_tax_form_preview_style__image\",\"page\":\"_src_tax_forms_tax_form_preview_style__page\",\"loading\":\"_src_tax_forms_tax_form_preview_style__loading\",\"pageError\":\"_src_tax_forms_tax_form_preview_style__pageError\",\"taxFormHeaderSkirt\":\"_src_tax_forms_tax_form_preview_style__taxFormHeaderSkirt\"};
module.exports = {\"cp-insufficient-permissions\":\"_src_common_page404__cp-insufficient-permissions\",\"cp-insufficient-permissions__block\":\"_src_common_page404__cp-insufficient-permissions__block\"};
module.exports = {\"label\":\"_src_source_forms_blocks_question_styles__label\",\"input\":\"_src_source_forms_blocks_question_styles__input\",\"inputBox\":\"_src_source_forms_blocks_question_styles__inputBox\"};
module.exports = {\"hoverState\":\"_src_source_forms_blocks_subheader_styles__hoverState\",\"subheader\":\"_src_source_forms_blocks_subheader_styles__subheader\"};
module.exports = {\"root\":\"_src_source_forms_blocks_informational_text_styles__root\"};
module.exports = {\"wrapper\":\"_src_source_forms_summary_table_summary_table_styles__wrapper\",\"actionBlock\":\"_src_source_forms_summary_table_summary_table_styles__actionBlock\",\"tableWrapper\":\"_src_source_forms_summary_table_summary_table_styles__tableWrapper\"};
module.exports = {\"currencyWrapper\":\"_src_source_forms_inputs_inputs_style__currencyWrapper\",\"currencyInput\":\"_src_source_forms_inputs_inputs_style__currencyInput\",\"radioCheck\":\"_src_source_forms_inputs_inputs_style__radioCheck\",\"source-form-400\":\"_src_source_forms_inputs_inputs_style__source-form-400\",\"source-form-320\":\"_src_source_forms_inputs_inputs_style__source-form-320\",\"source-form-200\":\"_src_source_forms_inputs_inputs_style__source-form-200\",\"source-form-104\":\"_src_source_forms_inputs_inputs_style__source-form-104\",\"source-form-88\":\"_src_source_forms_inputs_inputs_style__source-form-88\"};
module.exports = {\"questionBlock\":\"_src_source_forms_summary_table_summary_table_blocks_styles__questionBlock\"};
```
