### PR TITLE
Added separateCSS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+*.iml
 node_modules

--- a/src/nodeLoader.js
+++ b/src/nodeLoader.js
@@ -1,6 +1,6 @@
 /* eslint-env node */
 import AbstractLoader from './abstractLoader.js';
-import cssnano from 'cssnano';
+import cssnano from 'node-cssnano';
 import fs from 'fs';
 import path from 'path';
 

--- a/src/nodeLoader.js
+++ b/src/nodeLoader.js
@@ -1,6 +1,8 @@
 /* eslint-env node */
 import AbstractLoader from './abstractLoader.js';
 import cssnano from 'cssnano';
+import fs from 'fs';
+import path from 'path';
 
 // Append a <style> tag to the page and fill it with inline CSS styles.
 const cssInjectFunction = `(function(c){
@@ -8,6 +10,12 @@ const cssInjectFunction = `(function(c){
   d.head[a](s);
   s[i]?s[i].cssText=c:s[a](d.createTextNode(c));
 })`;
+// const cssInjectSourceMapsFunction = `(function(c){
+//   var d=document,a='appendChild',s=d.createElement('link');
+//   s.rel='stylesheet';
+//   s.href=URL.createObjectURL(new Blob([c],{type:'text/css'}));
+//   d.head[a](s);
+// })`;
 
 // Escape any whitespace characters before outputting as string so that data integrity can be preserved.
 const escape = (source) => {
@@ -27,35 +35,45 @@ const emptySystemRegister = (system, name) => {
   return `${system}.register('${name}', [], function() { return { setters: [], execute: function() {}}});`;
 };
 
+// const isWin = process.platform.match(/^win/);
+// function fromFileURL(url) {
+//   return url.substr(7 + !!isWin).replace(/\//g, isWin ? '\\' : '/');
+// }
+
+// const absRegEx = /^[a-z]+:/;
+
+// const cwd = process.cwd();
+
 export default class NodeLoader extends AbstractLoader {
   constructor(plugins) {
     super(plugins);
 
     this._injectableSources = [];
 
-    this.fetch = this.fetch.bind(this);
     this.bundle = this.bundle.bind(this);
-  }
-
-  fetch(load, systemFetch) {
-    return super.fetch(load, systemFetch)
-      .then((styleSheet) => {
-        this._injectableSources.push(styleSheet.injectableSource);
-        return styleSheet;
-      })
-      // Return the export tokens to the js files
-      .then((styleSheet) => styleSheet.exportedTokens);
+    this.fetch = this.fetch.bind(this);
   }
 
   bundle(loads, compileOpts, outputOpts) {
+    // let rootURL = outputOpts.rootURL;
+    // let browserRootURL = outputOpts.browserRootURL;
+
+    // if (rootURL && rootURL.substr(0, 5) == 'file:')
+    //   rootURL = fromFileURL(rootURL);
+
+    // if (browserRootURL && browserRootURL[browserRootURL.length - 1] !== '/')
+    //   browserRootURL += '/';
+
+    // const baseURLPath = fromFileURL(outputOpts.baseURL);
+
     /*eslint-disable no-console */
     if (outputOpts.buildCSS === false) {
       console.warn('Opting out of buildCSS not yet supported.');
     }
 
-    if (outputOpts.separateCSS === true) {
-      console.warn('Separting CSS not yet supported.');
-    }
+    // if (outputOpts.separateCSS === true) {
+    //   console.warn('Separting CSS not yet supported.');
+    // }
 
     if (outputOpts.sourceMaps === true) {
       console.warn('Source Maps not yet supported');
@@ -67,14 +85,57 @@ export default class NodeLoader extends AbstractLoader {
       // safe: true ensures no optimizations are applied which could potentially break the output.
       safe: true
     }).then((result) => {
-      // Take all of the CSS files which need to be output and generate a fake System registration for them.
-      // This will make System believe all files exist as needed.
-      // Then, take the combined output of all the CSS files and generate a single <style> tag holding all the info.
-      const fileDefinitions = loads
-        .map((load) => emptySystemRegister(compileOpts.systemGlobal || 'System', load.name))
-        .join('\n');
+      let cssOutput = result.css;
 
-      return `${fileDefinitions}${cssInjectFunction}('${escape(result.css)}');`;
+      if (outputOpts.separateCSS) {
+        const outFile = path.resolve(outputOpts.outFile).replace(/\.js$/, '.css');
+
+        // if (outputOpts.sourceMaps) {
+        //   fs.writeFileSync(`${outFile}.map`, result.map.toString());
+        //   cssOutput += `\n/*# sourceMappingUrl='${outFile.split(/[\\/]/).pop()}.map`;
+        // }
+
+        fs.writeFileSync(outFile, cssOutput);
+      } else {
+        // Take all of the CSS files which need to be output and generate a fake System registration for them.
+        // This will make System believe all files exist as needed.
+        // Then, take the combined output of all the CSS files and generate a single <style> tag holding all the info.
+        const fileDefinitions = loads
+          .map((load) => emptySystemRegister(compileOpts.systemGlobal || 'System', load.name))
+          .join('\n');
+
+        // if (outputOpts.sourceMaps && outputOpts.inlineCssSourceMaps) {
+        //   const sourceMap = JSON.parse(result.map.toString());
+        //
+        //   sourceMap.sources = sourceMap.sources.map(source => {
+        //     if (source.match(absRegEx))
+        //       return source;
+        //
+        //     if (source[0] !== '/')
+        //       source = path.resolve(baseURLPath, source);
+        //
+        //     if (outputOpts.rootURL)
+        //       return (outputOpts.browserRootURL || '/') + path.relative(outputOpts.rootURL, source).replace(/\\/g, '/');
+        //
+        //     return path.relative(baseURLPath, source).replace(/\\/g, '/');
+        //   });
+        //
+        //   cssOutput += `\n/*# sourceMappingURL=data:application/json;base64,${new Buffer(JSON.stringify(sourceMap)).toString('base64')}*/`;
+        //   return `${fileDefinitions}${cssInjectSourceMapsFunction}('${escape(cssOutput)}');`;
+        // }
+
+        return `${fileDefinitions}${cssInjectFunction}('${escape(cssOutput)}');`;
+      }
     });
+  }
+
+  fetch(load, systemFetch) {
+    return super.fetch(load, systemFetch)
+      .then((styleSheet) => {
+        this._injectableSources.push(styleSheet.injectableSource);
+        return styleSheet;
+      })
+      // Return the export tokens to the js files
+      .then((styleSheet) => styleSheet.exportedTokens);
   }
 }

--- a/src/nodeLoader.js
+++ b/src/nodeLoader.js
@@ -1,6 +1,6 @@
 /* eslint-env node */
 import AbstractLoader from './abstractLoader.js';
-import cssnano from 'node-cssnano';
+import cssnano from 'cssnano';
 import fs from 'fs';
 import path from 'path';
 


### PR DESCRIPTION
I added support for the separateCSS option available in "plugin-css" (it is actually an almost literal copy of their code). I also started working on sourcemap support but did not yet have time to finish so that part is commented out for the moment, but I thought I'd share the current version anyway since the separateCSS feature is a nice one to have when bundling your app (and it is easy to copy/paste it in the current version of the plugin).

I also used the 'node-cssnano' import instead of 'cssnano' since the latter is auto-created when you do "browser": {"cssnano": false} and the normal cssnano import is (in that case) going to redirect to @empty (or it should be once jspm 0.17 gets fixed, in my install it still get's linked to npm:cssnano which results in JS errors when running in the browser).
