### PR TITLE
decide node or browser through map config

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,11 @@
     "browser": {
       "cssnano": false
     }
+  },
+  "map": {
+    "./src/loader.js": {
+      "node": "./src/nodeLoader.js",
+      "browser": "./src/browserLoader.js"
+    }
   }
 }

--- a/src/loader.js
+++ b/src/loader.js
@@ -1,4 +1,0 @@
-import NodeLoader from './nodeLoader.js';
-import BrowserLoader from './browserLoader.js';
-
-export default typeof window === 'undefined' ? NodeLoader : BrowserLoader;


### PR DESCRIPTION
Couldn't get this to work in browsers. The `nodeLoader.js` had a dependency that couldn't work in a browser. This way `nodeLoader.js` doesn't even get loaded in browsers.