### PR TITLE
Creating cssOptions configuration options, including bundledStyleTagId

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ jspm install github:MeoMix/jspm-loader-css@master"
 
 and in `jspm.config.js` you'll need to add the following:
 
-```
+```js
 SystemJS.config({
   ...
   meta: {
     "*.css": {
-      "loader": "jspm-loader-css"
+      "loader": "jspm-loader-css",
+      "cssOptions": {}
     }
   },
   ...
@@ -106,6 +107,24 @@ export { fetch, bundle };
 Keep in mind that `jspm-loader-css` runs both in the browser (during development) and in node (during production builds). Many PostCSS plugins are written with only node in mind. Your mileage may vary on being able to successfully use PostCSS plugins without modification.
 
 For a working example of `jspm-loader-css` in `css.js`, see here: https://github.com/MeoMix/StreamusWebsite/blob/development/jspm/css.js
+
+## Passing cssOptions to jspm-loader-css
+To specify options to jspm-loader-css, provide a `cssOptions` configuration:
+```js
+SystemJS.config({
+  meta: {
+    "*.css": {
+      "loader": "jspm-loader-css",
+      "cssOptions": {
+        "bundledStyleTagId": "id-of-style-element"
+      }
+    }
+  },
+});
+```
+
+The options supported include:
+- `bundledStyleTagId`: a string that will be the `id` of the `<style>` element that contains the CSS for a bundled project. If not provided, the name of the first entry point being bundled will be used. When css files are not being bundled, this configuration option does not apply.
 
 ## Misc. Notes
 


### PR DESCRIPTION
Three things going on here:
- The creation of a `cssOptions` configuration where users can pass options into jspm-loader-css. This is an idea borrowed from [plugin-babel](https://github.com/systemjs/plugin-babel) which has `babelOptions`.
- Adding an option to cssOptions called `bundledStyleTagId`. I think the use case for this option is probably uncommon, but the motivation for me is that I want to be able hot-reload entire bundles that include css modules css. In order to do so, the `<style>` tag created during instantiation needs to be cleaned up. Otherwise, when the bundle is hotloaded the old `<style>` sticks around and a new one is injected. This results in duplicate declarations of css classes, and sometimes results in old CSS applying when it shouldn't (e.g., when a css attribute is removed from a class).
- Defaulting the `bundledStyleTagId` to the name of the first entry point being bundled. The hope is that this is a sane default for the users who care about the `id=""` and that it is a non-breaking change for those that don't.

Note that I have only added the option during bundling in the nodeLoader, and that this does not apply to the many style tags created if you are not bundling.